### PR TITLE
Add copy buttons to copy the HTML, component, and global CSS output code to the clipboard

### DIFF
--- a/public/main.html
+++ b/public/main.html
@@ -134,7 +134,7 @@
         </sl-tab-panel>
         <div style="display:none" id='copy'>
           <div style="display:flex;justify-content:center;align-items:center;">
-            <sl-button variant="success" outline>Copy output</sl-button>
+            <sl-icon-button name="clipboard" label="Edit" style="font-size: 1.5rem;"></sl-icon-button>            
           </div>
         </div>
       </sl-tab-group>
@@ -155,7 +155,7 @@
         </sl-tab-panel>
         <div style="display:none" id='copy'>
           <div style="display:flex;justify-content:center;align-items:center;">
-            <sl-button variant="success" outline>Copy output</sl-button>
+            <sl-icon-button name="clipboard" label="Edit" style="font-size: 1.5rem;"></sl-icon-button>
         </div>
         </div>
       </sl-tab-group>

--- a/public/main.html
+++ b/public/main.html
@@ -132,6 +132,11 @@
         <sl-tab-panel name="output">
           <codemirror-editor id="html-output" language-syntax="html"></codemirror-editor>
         </sl-tab-panel>
+        <div style="display:none" id='copy'>
+          <div style="display:flex;justify-content:center;align-items:center;">
+            <sl-button variant="success" outline>Copy output</sl-button>
+          </div>
+        </div>
       </sl-tab-group>
 
       <sl-tab-group>
@@ -148,6 +153,11 @@
         <sl-tab-panel name="global">
           <codemirror-editor id="css-output-global" language-syntax="css"></codemirror-editor>
         </sl-tab-panel>
+        <div style="display:none" id='copy'>
+          <div style="display:flex;justify-content:center;align-items:center;">
+            <sl-button variant="success" outline>Copy output</sl-button>
+        </div>
+        </div>
       </sl-tab-group>
     </section>
   </main-editors>

--- a/src/index.js
+++ b/src/index.js
@@ -175,6 +175,42 @@ const app = () => {
     }
     document.querySelector("#html-tabs").show("output")
 
+    const showCopyBtn = () => {
+      const buttons = document.querySelectorAll('#copy');
+      buttons.forEach((button) => {
+          button.style.display = "block";
+          button.addEventListener("click", (e) => {
+              const parent = e.target.closest('sl-tab-group');
+              const child = parent.querySelector('[aria-selected = "true"]');
+              const outputType = child.getAttribute('panel');
+              console.log(outputType)
+              let text = '';
+              switch (outputType) {
+                  case 'output':
+                      text = rootEl.innerHTML;
+                      break;
+                  case 'global':
+                      text = globalCSS().value;
+                      break;
+                  case 'component':
+                      text = componentCSS().value;
+                      break;
+                  default:
+                      text = '';
+              }
+              navigator.clipboard.writeText(text)
+                  .then(() => {
+                      // Получилось!
+                  })
+                  .catch(err => {
+                      console.log('Something went wrong', err);
+                  });
+          })
+      })
+  }
+
+showCopyBtn();
+
     let cssOutput = []
     nodeList.forEach((nodeData) => {
       if (nodeData.classes !== "" && !nodeData.same) {


### PR DESCRIPTION
Made copy buttons that are hidden by default, and after pressing "Run conversion" they are shown.
And depending on the tab open, it copies its content.
I'm not sure about styling, for now it looks like this, i used shoelace component.
![image](https://user-images.githubusercontent.com/66885436/189667279-037dd364-41d3-4fdf-a6b3-eb0a71308411.png)

